### PR TITLE
Fixed rendering bug for the first screen with simple delay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN apt-get update && apt-get -y install asciijump
 
 ENV TERM xterm-256color
 
-CMD /bin/bash -c /usr/games/asciijump
+CMD /bin/bash -c "sleep .1s && /usr/games/asciijump"
 


### PR DESCRIPTION
Looks like the terminal needs a bit of time until it'll give the game ability to draw anything. .1s should be enough.